### PR TITLE
Update pytorch multi-node test prometheus metrics GPU usage limit to 5%

### DIFF
--- a/tests/kfto/kfto_mnist_training_test.go
+++ b/tests/kfto/kfto_mnist_training_test.go
@@ -95,8 +95,8 @@ func runKFTOPyTorchMnistJob(t *testing.T, accelerator Accelerator, image string,
 					And(
 						HaveLen(numProcPerNode),
 						ContainElement(
-							// Check that at least some GPU was utilized on more than 20%
-							HaveField("Value", BeNumerically(">", 20)),
+							// Check that at least some GPU was utilized on more than 5%
+							HaveField("Value", BeNumerically(">", 5)),
 						),
 					),
 				)


### PR DESCRIPTION
- While using 2*g4dn.xlarge GPUs, the prometheus metric's GPU usage value shows min 20%
- While using A100 GPUS this usage percentage becomes negligible
- Updating value to at least 5% for the E2E QG tests
