### PR TITLE
Remove Sanity tag from VAP tests

### DIFF
--- a/tests/kfto/validating_admission_policy_test.go
+++ b/tests/kfto/validating_admission_policy_test.go
@@ -56,8 +56,6 @@ var (
 func TestValidatingAdmissionPolicy(t *testing.T) {
 	test := With(t)
 
-	Tags(t, Sanity)
-
 	// Create namespace with unique name and required labels
 	var AsDefaultQueueNamespace = ErrorOption[*corev1.Namespace](func(ns *corev1.Namespace) error {
 		if ns.Labels == nil {


### PR DESCRIPTION
Remove Sanity tag from VAP tests
cherry-pick of [444](https://github.com/opendatahub-io/distributed-workloads/pull/444)

## Description
In latest RHOAI 2.23 release, VAP and VAPB is no longer supported for kueue and now the Kueue label kueue.x-k8s.io/queue-name validation is handled by Kueue-validating-webhook. So removing sanity tag to avoid failure in test execution

## How Has This Been Tested?
No need to test

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
