### PR TITLE
Removing requests installation from Dockerfile for Python312 image

### DIFF
--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile
@@ -19,9 +19,6 @@ COPY LICENSE.md /licenses/cuda-license.md
 USER 0
 WORKDIR /app
 
-# upgrade requests package
-RUN pip install --no-cache-dir --upgrade requests==2.32.3
-
 # Install CUDA
 WORKDIR /opt/app-root/bin
 


### PR DESCRIPTION
Removing requests installation from Dockerfile as it was causing issues with the hermetic build. It seems to be included as a transitive dependency in the lock file in this image anyway. Have tested it with 3 examples, 1 training hub osft, 1 training hub sft and the training sft-llm example.

@m-rafeeq ptal, thanks.
cc @sutaakar 