### PR TITLE
Update rocm dockerfile to use ga index only

### DIFF
--- a/images/universal/training/th06-rocm64-torch291-py312/Dockerfile.konflux.rocm
+++ b/images/universal/training/th06-rocm64-torch291-py312/Dockerfile.konflux.rocm
@@ -25,7 +25,7 @@ USER 0
 WORKDIR /tmp/deps
 
 # Copy requirements files
-COPY --chown=1001:0 pyproject.toml requirements.txt requirements-ga.txt ./
+COPY --chown=1001:0 pyproject.toml requirements.txt ./
 
 # Switch to user 1001 for pip installations
 USER 1001
@@ -36,10 +36,7 @@ WORKDIR /opt/app-root/src
 # so we pass them explicitly as CLI flags
 RUN . /cachi2/cachi2.env && uv pip install --no-cache-dir \
     --no-index --find-links "${PIP_FIND_LINKS}" \
-    -r /tmp/deps/requirements.txt \
- && . /cachi2/cachi2.env && uv pip install --no-cache-dir \
-    --no-index --find-links "${PIP_FIND_LINKS}" \
-    -r /tmp/deps/requirements-ga.txt
+    -r /tmp/deps/requirements.txt
 
 # Fix permissions for OpenShift
 ARG PYTHON_VERSION


### PR DESCRIPTION
Updating rocm image to use ga index only due to an issue with fsdp.