### PR TITLE
Update cpu requirements ga file to fix build failure

### DIFF
--- a/images/universal/training/th06-cpu-torch291-py312/requirements-ga.txt
+++ b/images/universal/training/th06-cpu-torch291-py312/requirements-ga.txt
@@ -485,8 +485,30 @@ sentencepiece==0.2.1
     #   th06-cpu-universal-image (pyproject.toml)
     #   unsloth
     #   unsloth-zoo
+scikit-learn==1.8.0
+    # via
+    #   mlflow
+    #   skops
+scipy==1.17.1
+    # via
+    #   mlflow
+    #   scikit-learn
+    #   skops
+setuptools==80.10.2
+    # via
+    #   tensorboard
+    #   torch
+    #   training-hub
+shellingham==1.5.4
+    # via typer
 simpleeval==1.0.7
     # via th06-cpu-universal-image (pyproject.toml)
+six==1.17.0
+    # via
+    #   kubernetes
+    #   python-dateutil
+skops==0.13.0
+    # via mlflow
 smmap==5.0.3
     # via gitdb
 sqlalchemy==2.0.48


### PR DESCRIPTION
Add missing transitive dependencies to CPU requirements-ga.txt for Konflux offline builds

  Details

  The Konflux build uses --no-index --find-links (cachi2 offline cache), so every package must be explicitly listed in
  the requirements files for cachi2 to prefetch it. The midstream build uses live indexes which resolve transitive deps
  automatically, so these gaps were never caught until the downstream Konflux build hit them.

  Added 6 missing transitive dependencies:
  - scikit-learn==1.8.0, scipy==1.17.1, skops==0.13.0 — required by mlflow
  - setuptools==80.10.2 — required by tensorboard, torch, training-hub
  - shellingham==1.5.4 — required by typer
  - six==1.17.0 — required by kubernetes, python-dateutil

  Follows up on #742 and #743.