### PR TITLE
Restore taskRunSpecs for ROCm training image builds

### DIFF
--- a/.tekton/odh-training-rocm62-torch24-py311-v2-25-push.yaml
+++ b/.tekton/odh-training-rocm62-torch24-py311-v2-25-push.yaml
@@ -47,6 +47,23 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+  taskRunSpecs:
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-training-rocm62-torch25-py311-v2-25-push.yaml
+++ b/.tekton/odh-training-rocm62-torch25-py311-v2-25-push.yaml
@@ -47,6 +47,23 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+  taskRunSpecs:
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Restores `taskRunSpecs` for `build-images` and `clair-scan` pipeline tasks in the ROCm training image PipelineRuns
- These were accidentally removed in fdb9e70 during the konflux-central sync
- Affected files: `odh-training-rocm62-torch24-py311-v2-25-push.yaml` and `odh-training-rocm62-torch25-py311-v2-25-push.yaml`

## Why
The `taskRunSpecs` provide elevated CPU/memory resources needed for building the large ROCm images and running clair vulnerability scans. Without them, builds may fail with OOM or run significantly slower.
