### PR TITLE
Manually align ROCm tekton pipeline with upstream ODH stable

### DIFF
--- a/.tekton/ray-2.54.1-py312-rocm64-push.yaml
+++ b/.tekton/ray-2.54.1-py312-rocm64-push.yaml
@@ -9,13 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" 
       && target_branch == "main" 
-      && ( "images/runtime/ray/rocm/2.53.0-py312-rocm64/**".pathChanged() || ".tekton/ray-2.53.0-py312-rocm64-push.yaml".pathChanged() )
+      && ( "images/runtime/ray/rocm/2.54.1-py312-rocm64/**".pathChanged() || ".tekton/ray-2.54.1-py312-rocm64-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: runtime-ray
     appstudio.openshift.io/component: ray-rocm
     pipelines.appstudio.openshift.io/type: build
-  name: ray-rocm-2.53.0-py312-rocm64-on-push
+  name: ray-rocm-2.54.1-py312-rocm64-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -24,13 +24,13 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/modh/ray:2.53.0-py312-rocm64
+    value: quay.io/modh/ray:2.54.1-py312-rocm64
   - name: additional-tag
-    value: 2.53.0-py312-rocm64-{{revision}}
+    value: 2.54.1-py312-rocm64-{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context
-    value: images/runtime/ray/rocm/2.53.0-py312-rocm64
+    value: images/runtime/ray/rocm/2.54.1-py312-rocm64
   taskRunSpecs:
     - pipelineTaskName: build-container
       stepSpecs:
@@ -245,7 +245,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.2@sha256:6620f885c459e0e062c44797a4fc7b0f28c54c117de3771234b065c76714f663
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.8@sha256:40cfd115345e01830c59e0c4f1fab15120e6cb1f78ff0082f328108b9a3a2072
         - name: kind
           value: task
         resolver: bundles
@@ -476,4 +476,3 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 status: {}
-#restart


### PR DESCRIPTION
The auto-merge sync silently dropped upstream content changes due to a downstream-only commit (f520ef7e) that caused `merge=ours` to resolve in favour of the stale downstream version. This replaces the file content with the current ODH stable version to re-align and prevent the same issue on future version bumps and hopefully kick off the rocm runtime image build