### PR TITLE
update base images using temp images

### DIFF
--- a/images/universal/training/th06-cpu-torch210-py312/Dockerfile.konflux.cpu
+++ b/images/universal/training/th06-cpu-torch210-py312/Dockerfile.konflux.cpu
@@ -12,7 +12,7 @@
 ################################################################################
 # Build Arguments
 ################################################################################
-ARG BASE_IMAGE=quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:2b77df73a0abce02d14b5a16ba421888037460b1719bd9e8b830a08147182102
+ARG BASE_IMAGE=quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:71b6aee897c14a0e8392e1fdd30a182adc86067d9bdf3a2c5605699c7cec261d
 ARG PYTHON_VERSION=3.12
 ARG DOWNSTREAM=false
 

--- a/images/universal/training/th06-cuda130-torch210-py312/Dockerfile.konflux.cuda
+++ b/images/universal/training/th06-cuda130-torch210-py312/Dockerfile.konflux.cuda
@@ -13,7 +13,7 @@
 ################################################################################
 # Build Arguments
 ################################################################################
-ARG BASE_IMAGE=quay.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:fa1dc9248e0f594cb2254953483591280b64ce7f3605a472b460ac89665ea958
+ARG BASE_IMAGE=quay.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:767f9d39b79c8d2d0613716349606926a43ee038eca689ab28ac67caa9d3224e
 ARG PYTHON_VERSION=3.12
 ARG DOWNSTREAM=false
 

--- a/images/universal/training/th06-rocm64-torch291-py312/Dockerfile.konflux.rocm
+++ b/images/universal/training/th06-rocm64-torch291-py312/Dockerfile.konflux.rocm
@@ -12,7 +12,7 @@
 ################################################################################
 # Build Arguments
 ################################################################################
-ARG BASE_IMAGE=quay.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:8580e08c4d8a5ec4a8ec6ddb340bbcc0c4de6966c21ad84600d1058fe68ece4e
+ARG BASE_IMAGE=quay.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:c7bf1787326be2763b1812e64cf521e2487bac1f3985ba6f3ee79c97da06f61f
 ARG PYTHON_VERSION=3.12
 ARG DOWNSTREAM=false
 


### PR DESCRIPTION
The 3.4 released images should not be using latest 3.5-ea1 base images as nudges since their state must be exactly as it was at GA release. 
The nudging is only required for the initial release of the images and then, disabled for the support period of the image.