### PR TITLE
update base image for th06 to use digests

### DIFF
--- a/images/universal/training/th06-cpu-torch210-py312/Dockerfile.konflux.cpu
+++ b/images/universal/training/th06-cpu-torch210-py312/Dockerfile.konflux.cpu
@@ -12,7 +12,7 @@
 ################################################################################
 # Build Arguments
 ################################################################################
-ARG BASE_IMAGE=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9:v3.4.0-1777915689
+ARG BASE_IMAGE=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:01b22d2179dfa4cb57ff042a2c87c9082e2c57f331b818218b690c9a747b168e
 ARG PYTHON_VERSION=3.12
 ARG DOWNSTREAM=false
 

--- a/images/universal/training/th06-cuda130-torch210-py312/Dockerfile.konflux.cuda
+++ b/images/universal/training/th06-cuda130-torch210-py312/Dockerfile.konflux.cuda
@@ -13,7 +13,7 @@
 ################################################################################
 # Build Arguments
 ################################################################################
-ARG BASE_IMAGE=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9:v3.4.0-1777915689
+ARG BASE_IMAGE=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:8bacb849ae17424c4b613ed50089ae24b7ea69e92cdb4f558f561d2031e153b9
 ARG PYTHON_VERSION=3.12
 ARG DOWNSTREAM=false
 

--- a/images/universal/training/th06-rocm64-torch291-py312/Dockerfile.konflux.rocm
+++ b/images/universal/training/th06-rocm64-torch291-py312/Dockerfile.konflux.rocm
@@ -12,7 +12,7 @@
 ################################################################################
 # Build Arguments
 ################################################################################
-ARG BASE_IMAGE=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9:v3.4.0-1777507213
+ARG BASE_IMAGE=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:496b9ff80594d486f594bba69652c3ae4445265b94a44995b25f5ebd1e5767b3
 ARG PYTHON_VERSION=3.12
 ARG DOWNSTREAM=false
 


### PR DESCRIPTION
Update TH06 images to use digests for base images

- https://catalog.redhat.com/en/software/containers/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9/688d13bb8bd4d1d30c5aba4e#get-this-image
- https://catalog.redhat.com/en/software/containers/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9/688d13bc101e534d17cda26e#get-this-image
- https://catalog.redhat.com/en/software/containers/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9/688d13bb3c311a654715fd7a#get-this-image