### PR TITLE
[RHOAI 3.4] Pin MLNX OFED repo and update urllib3 to 2.7.0

### DIFF
--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile
@@ -53,7 +53,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda121-torch241/Pipfile
+++ b/images/runtime/training/py311-cuda121-torch241/Pipfile
@@ -32,6 +32,7 @@ tensorboard = "2.19.0"
 fsspec = ">=2025.3.0"
 s3fs = ">=2025.3.0"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-cuda121-torch241/Pipfile.lock
+++ b/images/runtime/training/py311-cuda121-torch241/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e1d7d0de57f005fe7065a91714aca3cfcb9d6065589b971e49ea4c5aa37a7d7e"
+            "sha256": "19190f465a629e4a7b0ac975b96b61768b053fe625a0840230a6ade31782da5e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2326,11 +2326,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile
@@ -53,7 +53,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda124-torch251/Pipfile
+++ b/images/runtime/training/py311-cuda124-torch251/Pipfile
@@ -32,6 +32,7 @@ tensorboard = "2.19.0"
 fsspec = ">=2025.3.0"
 s3fs = ">=2025.3.0"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-cuda124-torch251/Pipfile.lock
+++ b/images/runtime/training/py311-cuda124-torch251/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6b485e71f60fd5cfe677b1051ebc98bc6256659d13feb44e57bd39709d07a647"
+            "sha256": "4c81d3a999f0ab2fe8ba7affd6271c16268814ef0e1eeac59616505abb5df423"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2330,11 +2330,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py311-rocm62-torch241/Pipfile
+++ b/images/runtime/training/py311-rocm62-torch241/Pipfile
@@ -37,6 +37,7 @@ tensorboard = "2.19.0"
 fsspec = ">=2025.3.0"
 s3fs = ">=2025.3.0"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-rocm62-torch241/Pipfile.lock
+++ b/images/runtime/training/py311-rocm62-torch241/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c9acd81eeb249f946376ec1bb8f2b8b0379fd81b16a8be7f97d307ceffb63176"
+            "sha256": "827806b85ec1a8ddbb29d555c3b4a2a370a6348b2d9053057612c36bb999aaa4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2244,11 +2244,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py311-rocm62-torch251/Pipfile
+++ b/images/runtime/training/py311-rocm62-torch251/Pipfile
@@ -37,6 +37,7 @@ tensorboard = "2.19.0"
 fsspec = ">=2025.3.0"
 s3fs = ">=2025.3.0"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-rocm62-torch251/Pipfile.lock
+++ b/images/runtime/training/py311-rocm62-torch251/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c70edd9a0dce909d8a9058bcff5adfcd0efaec8b0e56878ad02caf15fc26e615"
+            "sha256": "c06d980cd45da84faa9868281b035b431dd062563f96d7d9f9c567ae08396f56"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2243,11 +2243,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile
@@ -66,7 +66,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
@@ -54,7 +54,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch280/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch280/Pipfile
@@ -41,6 +41,7 @@ fsspec = ">=2025.3.0"
 s3fs = ">=2025.3.0"
 wheel = ">=0.46.2,<1"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5abd450f2d9d5af51bbc2d03d20b3bfd34bfcca5c0336aa4c0d830c91178b387"
+            "sha256": "46c990c5e289e77fe9dd6b44f03f232f9d038797723636aa5026b216ff59517c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2393,11 +2393,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile
@@ -66,7 +66,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
@@ -62,7 +62,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch290/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile
@@ -49,6 +49,7 @@ s3fs = ">=2025.3.0"
 pyasn1 = "==0.6.3"
 mlflow = "==3.10.1"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "de6b56a6821e2cd5eb6da8c79f814143f0fb4d33831f34f50dd2fcf3b9a8c896"
+            "sha256": "4399dd708006a42f9d2e9a8972088ab5bc55a8789ff7ce3aeca1467fbbcc9e96"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -3786,11 +3786,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "uvicorn": {
             "hashes": [

--- a/images/runtime/training/py312-rocm64-torch280/Pipfile
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile
@@ -45,6 +45,7 @@ fsspec = ">=2025.3.0"
 s3fs = ">=2025.3.0"
 wheel = ">=0.46.2,<1"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "96630553dafee0cc454f198c06127b20ff14df75f58d5db59d4ee5b6c23d2733"
+            "sha256": "10b20884f80aa66d8d8a6d57a0a81dc5617b37fd0e41c8923c63df93f3769524"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2326,11 +2326,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "uv": {
             "hashes": [

--- a/images/runtime/training/py312-rocm64-torch290/Pipfile
+++ b/images/runtime/training/py312-rocm64-torch290/Pipfile
@@ -43,6 +43,7 @@ training-hub = {version = "==0.5.0", extras = ["lora"]}
 fsspec = ">=2025.3.0"
 s3fs = ">=2025.3.0"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-rocm64-torch290/Pipfile.lock
+++ b/images/runtime/training/py312-rocm64-torch290/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c0489b1dcacac0ac6cc9aee69fdef17f2d03a6e051ba0387f8a6a76f3bda5f41"
+            "sha256": "ca6047520cc4e525fa01a919c242e93779a71d2caaf5500f187cdec3abd2c2f6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2612,11 +2612,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [


### PR DESCRIPTION
## Summary
- Pins MLNX OFED repo URL from `latest` to `24.10-1.1.4.0` — the `latest` symlink no longer includes `rhel9.5`, causing 404 during image builds
- Updates urllib3 from 2.6.3 to 2.7.0 across all training runtime images (CVE-2026-44432: DoS via excessive HTTP response decompression)

## Test plan
- [ ] Verify affected training images build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)