### PR TITLE
[RHOAI 2.25] Pin MLNX OFED repo and update urllib3 to 2.7.0

### DIFF
--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile
@@ -53,7 +53,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda121-torch241/Pipfile
+++ b/images/runtime/training/py311-cuda121-torch241/Pipfile
@@ -31,7 +31,7 @@ aiofiles = ">=23.2.1"
 async-timeout = "==4.0.3"
 tensorboard = "2.19.0"
 aiohttp = ">=3.13.3"
-urllib3 = ">=2.6.3"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-cuda121-torch241/Pipfile.lock
+++ b/images/runtime/training/py311-cuda121-torch241/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c9c2c571fa0e718a871e0002fb9da29de61bedf4b673caf05443fd3e3ec9c8ea"
+            "sha256": "bb31a9f450fe3247b5a9ed559579ea88a7a655fc9076cd896ecb6adf02a2f4a3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1918,11 +1918,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile
@@ -53,7 +53,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda124-torch251/Pipfile
+++ b/images/runtime/training/py311-cuda124-torch251/Pipfile
@@ -31,7 +31,7 @@ aiofiles = ">=23.2.1"
 async-timeout = "==4.0.3"
 tensorboard = "2.19.0"
 aiohttp = ">=3.13.3"
-urllib3 = ">=2.6.3"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-cuda124-torch251/Pipfile.lock
+++ b/images/runtime/training/py311-cuda124-torch251/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fe326822b530d2d96168de3de5ca4dc14ba165ec79194938572a2b4d68718436"
+            "sha256": "a68e0dc79ebc8bfa511d892ce3f64eb150065ecfe10f0f2653640db274c042cb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1961,11 +1961,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py311-rocm62-torch241/Pipfile
+++ b/images/runtime/training/py311-rocm62-torch241/Pipfile
@@ -36,7 +36,7 @@ aiofiles = ">=23.2.1"
 async-timeout = "==4.0.3"
 tensorboard = "2.19.0"
 aiohttp = ">=3.13.3"
-urllib3 = ">=2.6.3"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-rocm62-torch241/Pipfile.lock
+++ b/images/runtime/training/py311-rocm62-torch241/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ead10a8dd924e99e3eb18f4baa3fa3ab770b752a03205e4077e934264f737cd6"
+            "sha256": "7e79a0a22836711ed28e29abd9a657325289cdac47025444489849bdcd7269dc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1812,11 +1812,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py311-rocm62-torch251/Pipfile
+++ b/images/runtime/training/py311-rocm62-torch251/Pipfile
@@ -36,7 +36,7 @@ aiofiles = ">=23.2.1"
 async-timeout = "==4.0.3"
 tensorboard = "2.19.0"
 aiohttp = ">=3.13.3"
-urllib3 = ">=2.6.3"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-rocm62-torch251/Pipfile.lock
+++ b/images/runtime/training/py311-rocm62-torch251/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9175e52bffa1a5c2a16c9573a25cf6e77de5f2a6587c032e7d8f682850c89ab4"
+            "sha256": "9fe4edc0f720058b998d189328677cbdc1f5aed0a4146e7a1987f050aa112c3e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1849,11 +1849,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [


### PR DESCRIPTION
## Summary
- Pins MLNX OFED repo URL from `latest` to `24.10-1.1.4.0` — the `latest` symlink no longer includes `rhel9.5`, causing 404 during image builds
- Updates urllib3 from 2.6.3 to 2.7.0 across all training runtime images (CVE-2026-44432: DoS via excessive HTTP response decompression)

## Test plan
- [ ] Verify affected training images build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)