### PR TITLE
[RHOAI 3.3] Pin MLNX OFED repo and update urllib3 to 2.7.0

### DIFF
--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile
@@ -53,7 +53,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda121-torch241/Pipfile
+++ b/images/runtime/training/py311-cuda121-torch241/Pipfile
@@ -30,6 +30,7 @@ aiofiles = ">=23.2.1"
 async-timeout = "==4.0.3"
 tensorboard = "2.19.0"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-cuda121-torch241/Pipfile.lock
+++ b/images/runtime/training/py311-cuda121-torch241/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3de1e169eba71e9ac6594d702b56b70929570d02eb16f7aed5d57d1c11c63bfd"
+            "sha256": "31739cdcef9c6aea3a5ae35ee7401449aa409df1ad8150d752d5aba00433639f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2259,11 +2259,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile
@@ -53,7 +53,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda124-torch251/Pipfile
+++ b/images/runtime/training/py311-cuda124-torch251/Pipfile
@@ -30,6 +30,7 @@ aiofiles = ">=23.2.1"
 async-timeout = "==4.0.3"
 tensorboard = "2.19.0"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-cuda124-torch251/Pipfile.lock
+++ b/images/runtime/training/py311-cuda124-torch251/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "696a915cffb6f2e819f80863597deee4484215fcf1b72021ec8d688d3de6e502"
+            "sha256": "2ad3a817878e65a80165a6ac60a793df236210ef92f81f5954a7e049f3d533d1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2265,11 +2265,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py311-rocm62-torch241/Pipfile
+++ b/images/runtime/training/py311-rocm62-torch241/Pipfile
@@ -35,6 +35,7 @@ aiofiles = ">=23.2.1"
 async-timeout = "==4.0.3"
 tensorboard = "2.19.0"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-rocm62-torch241/Pipfile.lock
+++ b/images/runtime/training/py311-rocm62-torch241/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f8c97f4f480fca0960b2900aae845a24bd26a940da2209dbb4b696e29de7987e"
+            "sha256": "7eb194079cb80c8cd56d1864c48fa4e71d7098b5b94fbe82289fa0b90a027f94"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2161,11 +2161,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py311-rocm62-torch251/Pipfile
+++ b/images/runtime/training/py311-rocm62-torch251/Pipfile
@@ -35,6 +35,7 @@ aiofiles = ">=23.2.1"
 async-timeout = "==4.0.3"
 tensorboard = "2.19.0"
 simpleeval = "==1.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py311-rocm62-torch251/Pipfile.lock
+++ b/images/runtime/training/py311-rocm62-torch251/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1ef92a9c7c9f18c2e2791eb4a1bd19ba493d2cc26fe547870a3fc29b27835ae7"
+            "sha256": "311adec0c52cac7b08b0db604671049b7aa7f4bf763b345fd1b4a3e8d431a92c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2160,11 +2160,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile
@@ -66,7 +66,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
@@ -54,7 +54,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch280/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch280/Pipfile
@@ -39,6 +39,7 @@ hf-xet = "==1.1.8"
 huggingface-hub = "==0.34.4"
 psutil = "==7.0.0"
 wheel = ">=0.46.2"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "85b84e4033468f1e176183c7a002958087f57a5340b6dca61560dcca837e7245"
+            "sha256": "a2031b710e6c201a50055f6f0cde42710c43f1d99e6a89d68d7e63a78cd98caf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2358,11 +2358,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [

--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile
@@ -66,7 +66,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
@@ -62,7 +62,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch290/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile
@@ -48,6 +48,7 @@ deprecated = "==1.3.1"
 pyasn1 = "==0.6.3"
 mlflow = "==3.10.1"
 cryptography = ">=46.0.7"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4132732871c271400166521e5d402928bda8ec8ec8be8046935ad397d4210d08"
+            "sha256": "dc643426ca5fb864b81a708d6c57a86532011679b541f5f0a3147e30a5d47506"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -3748,11 +3748,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "uvicorn": {
             "hashes": [

--- a/images/runtime/training/py312-rocm64-torch280/Pipfile
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile
@@ -43,6 +43,7 @@ aiofiles = "==24.1.0"
 async-timeout = "==4.0.3"
 tensorboard = "2.19.0"
 wheel = ">=0.46.2"
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7a76f4671df302e03bb19a8642de7afe3c1236557fddb706b8b222e6478b6fe8"
+            "sha256": "75312b8f60b4c995cc7b58465a75007bd429739cb7f7172c9f1e676fb2e4918d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2282,11 +2282,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "uv": {
             "hashes": [

--- a/images/runtime/training/py312-rocm64-torch290/Pipfile
+++ b/images/runtime/training/py312-rocm64-torch290/Pipfile
@@ -41,6 +41,7 @@ huggingface-hub = "==0.35.3"
 hf-xet = "==1.2.0"
 trl = "==0.24.0"
 training-hub = {version = "==0.5.0", extras = ["lora"]}
+urllib3 = ">=2.7.0"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-rocm64-torch290/Pipfile.lock
+++ b/images/runtime/training/py312-rocm64-torch290/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2b04d3a7b8359d804b04d00c84e8e89d810ff25a6ed0340f926d464d3710c9fc"
+            "sha256": "6544f4358ee2c4256a8dd79cc5f8f244ae9be7cf7deaa16a02335714702862af"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2562,11 +2562,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
-                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.3"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "werkzeug": {
             "hashes": [


### PR DESCRIPTION
## Summary
- Pins MLNX OFED repo URL from `latest` to `24.10-1.1.4.0` — the `latest` symlink no longer includes `rhel9.5`, causing 404 during image builds
- Updates urllib3 from 2.6.3 to 2.7.0 across all training runtime images (CVE-2026-44432: DoS via excessive HTTP response decompression)

## Test plan
- [ ] Verify affected training images build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)