### PR TITLE
Pin MLNX OFED repo to 24.10-1.1.4.0 for rhel9.5 compatibility

### DIFF
--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
@@ -54,7 +54,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
@@ -62,7 +62,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \


### PR DESCRIPTION
The "latest" symlink no longer includes rhel9.5, causing 404 during image builds. Pin to exact version 24.10-1.1.4.0 to match the --enablerepo name and align with universal images.