### PR TITLE
[RHOAI 3.4] RHOAIENG-64906: Update starlette to 1.0.1 in py312-cuda128-torch290

### DIFF
--- a/images/runtime/training/py312-cuda128-torch290/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile
@@ -50,6 +50,7 @@ pyasn1 = "==0.6.3"
 mlflow = "==3.10.1"
 simpleeval = "==1.0.7"
 urllib3 = ">=2.7.0"
+starlette = ">=1.0.1"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4399dd708006a42f9d2e9a8972088ab5bc55a8789ff7ce3aeca1467fbbcc9e96"
+            "sha256": "c4559db5f8f2c2dfe5f0c0cfa60503369bd407cc4eb93adc2c95833156e9fda6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -3523,11 +3523,12 @@
         },
         "starlette": {
             "hashes": [
-                "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149",
-                "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"
+                "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f",
+                "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==1.0.0"
+            "version": "==1.0.1"
         },
         "sympy": {
             "hashes": [


### PR DESCRIPTION
Bump starlette from 1.0.0 to 1.0.1 to fix CVE-2026-48710, a security restriction bypass via malformed HTTP Host header.