### PR TITLE
CVE-2026-48710: Update starlette in universal training images [rhoai-3.4]

### DIFF
--- a/images/universal/training/th06-cpu-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cpu-torch210-py312/requirements.txt
@@ -515,7 +515,7 @@ sqlalchemy==2.0.49
     #   mlflow
 sqlparse==0.5.5
     # via mlflow-skinny
-starlette==1.0.0
+starlette==1.2.0
     # via fastapi
 sympy==1.14.0
     # via

--- a/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
@@ -608,7 +608,7 @@ sqlalchemy==2.0.49
     #   mlflow
 sqlparse==0.5.5
     # via mlflow-skinny
-starlette==1.0.0
+starlette==1.2.0
     # via fastapi
 sympy==1.14.0
     # via

--- a/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
+++ b/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
@@ -592,7 +592,7 @@ sqlalchemy==2.0.49
     #   mlflow
 sqlparse==0.5.5
     # via mlflow-skinny
-starlette==1.0.0
+starlette==1.2.0
     # via fastapi
 sympy==1.14.0
     # via


### PR DESCRIPTION
## Summary
- Cherry-picks starlette CVE-2026-48710 fixes for universal training images from upstream main
- Updates `starlette` from `1.0.0` to `1.2.0` in:
  - `th06-cpu-torch210-py312`
  - `th06-rocm64-torch291-py312`
  - `th06-cuda130-torch210-py312`

## Cherry-picked commits
- RHOAIENG-64921: odh-th06-cuda130-torch210-py312-rhel9
- RHOAIENG-64912: odh-th06-rocm64-torch291-py312-rhel9
- RHOAIENG-64929: odh-th06-cpu-torch210-py312-rhel9