### PR TITLE
Pin Mellanox OFED repo to version 24.10-1.1.4.0

### DIFF
--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
@@ -41,7 +41,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo \
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo \
     && dnf install -y \
         libibverbs-utils \
         infiniband-diags \

--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
@@ -54,7 +54,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \

--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
@@ -62,7 +62,7 @@ ENV CUDA_HOME="/usr/local/cuda" \
 
 # Install InfiniBand and RDMA packages
 RUN dnf config-manager \
-        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/latest/rhel9.5/mellanox_mlnx_ofed.repo 
+        --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-1.1.4.0/rhel9.5/mellanox_mlnx_ofed.repo 
 
 RUN dnf install -y --disablerepo="*" --enablerepo="cuda-rhel9-x86_64,mlnx_ofed_24.10-1.1.4.0_base,ubi-9-appstream-rpms,ubi-9-baseos-rpms" \
         libibverbs-utils \


### PR DESCRIPTION
## Summary
- Pin Mellanox OFED repo URL from `latest` to `24.10-1.1.4.0` in 4 CUDA training Dockerfiles
- The `latest` path on linux.mellanox.com no longer includes `rhel9.5`, causing 404 errors on all training builds
- This matches the fix already applied on the `main` branch

## Test plan
- [ ] Verify builds pass for the 4 affected training components (odh-training-cuda121-torch24-py311, odh-training-cuda124-torch25-py311, odh-training-cuda128-torch28-py312, odh-training-cuda128-torch29-py312)

🤖 Generated with [Claude Code](https://claude.com/claude-code)