### PR TITLE
RHOAIENG-66285: CVE-2026-5241 rhoai/odh-th06-rocm64-torch291-py312-rhel9: python-transformers: Arbitrary code execution due to overridden trust_remote_code setting [rhoai-3.4]

### DIFF
--- a/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
+++ b/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # ML Training and Inference Libraries
     "peft==0.18.1",
     "datasets==4.3.0",
-    "transformers==4.57.6",
+    "transformers~=5.5.0",
     "accelerate==1.12.0",
     "trl==0.24.0",
     
@@ -68,7 +68,7 @@ dependencies = [
     "training_hub[lora]==0.6.0",
     "instructlab-training==0.14.2",
     "rhai-innovation-mini-trainer==0.6.1",
-    "unsloth==2026.3.3",
+    "unsloth~=2026.4.5",
     
     # Kubeflow SDK
     "kubeflow==0.3.0+rhaiv.2",

--- a/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
+++ b/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
@@ -135,7 +135,6 @@ filelock==3.25.2
     #   huggingface-hub
     #   torch
     #   training-hub
-    #   transformers
     #   unsloth-zoo
 flash-attn==2.8.3
     # via th06-rocm-universal-image (pyproject.toml)
@@ -206,9 +205,10 @@ httpx==0.28.1
     # via
     #   datasets
     #   diffusers
+    #   huggingface-hub
 huey==2.6.0
     # via mlflow
-huggingface-hub==0.36.2
+huggingface-hub==1.10.2
     # via
     #   accelerate
     #   datasets
@@ -312,6 +312,8 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   training-hub
+nest-asyncio==1.6.0
+    # via unsloth
 nest-asyncio2==1.7.2
     # via model-registry
 networkx==3.6.1
@@ -475,6 +477,7 @@ pydantic==2.12.5
     #   mlflow-tracing
     #   model-registry
     #   training-hub
+    #   unsloth
 pydantic-core==2.41.5
     # via pydantic
 pygments==2.20.0
@@ -515,6 +518,7 @@ pyyaml==6.0.3
     #   mlflow-skinny
     #   peft
     #   transformers
+    #   unsloth
 regex==2026.4.4
     # via
     #   diffusers
@@ -527,12 +531,10 @@ requests==2.33.1
     #   datasets
     #   diffusers
     #   docker
-    #   huggingface-hub
     #   kubernetes
     #   mlflow-skinny
     #   requests-oauthlib
     #   training-hub
-    #   transformers
 requests-oauthlib==2.0.0
     # via kubernetes
 rhai-innovation-mini-trainer==0.6.1
@@ -640,7 +642,7 @@ tqdm==4.67.3
     #   unsloth-zoo
 training-hub==0.6.0
     # via th06-rocm-universal-image (pyproject.toml)
-transformers==4.57.6
+transformers==5.5.0
     # via
     #   th06-rocm-universal-image (pyproject.toml)
     #   instructlab-training
@@ -668,7 +670,11 @@ trl==0.24.0
 typeguard==4.5.1
     # via tyro
 typer==0.24.1
-    # via rhai-innovation-mini-trainer
+    # via
+    #   huggingface-hub
+    #   rhai-innovation-mini-trainer
+    #   transformers
+    #   unsloth
 typing-extensions==4.15.0
     # via
     #   aiosignal
@@ -702,11 +708,11 @@ tyro==1.0.12
     #   unsloth-zoo
 tzdata==2026.1
     # via pandas
-unsloth==2026.3.3
+unsloth==2026.4.5
     # via
     #   th06-rocm-universal-image (pyproject.toml)
     #   training-hub
-unsloth-zoo==2026.4.3
+unsloth-zoo==2026.4.7
     # via unsloth
 urllib3==2.7.0
     # via


### PR DESCRIPTION
## Summary
Cherry-pick of opendatahub-io/distributed-workloads#902 to rhoai-3.4.

- Bump transformers from 4.57.6 to 5.5.0 to fix CVE-2026-5241
- Bump unsloth from 2026.3.3 to 2026.4.5 (and unsloth-zoo from 2026.4.3 to 2026.4.7) for compatibility
- Upgrade huggingface-hub from 0.36.2 to 1.10.2 as required by the new transformers version

## Test plan
- [ ] Konflux build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)