### PR TITLE
RHOAIENG-66266: CVE-2026-5241 rhoai/odh-th06-cpu-torch210-py312-rhel9: python-transformers: Arbitrary code execution due to overridden trust_remote_code setting [rhoai-3.4]

### DIFF
--- a/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # ML Training and Inference Libraries
     "peft==0.18.1",
     "datasets==4.3.0",
-    "transformers==4.57.6",
+    "transformers~=5.5.0",
     "accelerate==1.12.0",
     "trl==0.24.0",
     

--- a/images/universal/training/th06-cpu-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cpu-torch210-py312/requirements.txt
@@ -116,7 +116,6 @@ filelock==3.28.0
     #   huggingface-hub
     #   torch
     #   training-hub
-    #   transformers
 flask==3.1.3
     # via
     #   flask-cors
@@ -175,10 +174,12 @@ hf-xet==1.4.3
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
-    # via datasets
+    # via
+    #   datasets
+    #   huggingface-hub
 huey==2.6.0
     # via mlflow
-huggingface-hub==0.36.2
+huggingface-hub==1.13.0
     # via
     #   accelerate
     #   datasets
@@ -454,12 +455,10 @@ requests==2.33.1
     #   databricks-sdk
     #   datasets
     #   docker
-    #   huggingface-hub
     #   kubernetes
     #   mlflow-skinny
     #   requests-oauthlib
     #   training-hub
-    #   transformers
 requests-oauthlib==2.0.0
     # via kubernetes
 rhai-innovation-mini-trainer==0.6.1
@@ -548,7 +547,7 @@ tqdm==4.67.3
     #   transformers
 training-hub==0.6.0
     # via th06-cpu-universal-image (pyproject.toml)
-transformers==4.57.6
+transformers==5.5.4
     # via
     #   th06-cpu-universal-image (pyproject.toml)
     #   instructlab-training
@@ -565,7 +564,10 @@ trl==0.24.0
     #   th06-cpu-universal-image (pyproject.toml)
     #   instructlab-training
 typer==0.24.1
-    # via rhai-innovation-mini-trainer
+    # via
+    #   huggingface-hub
+    #   rhai-innovation-mini-trainer
+    #   transformers
 typing-extensions==4.15.0
     # via
     #   aiosignal


### PR DESCRIPTION
## Summary
Cherry-pick of opendatahub-io/distributed-workloads#905 to rhoai-3.4.

- Bump transformers from 4.57.6 to 5.5.4 to fix CVE-2026-5241
- Constraint changed from ==4.57.6 to ~=5.5.0 in pyproject.toml
- Requirements regenerated via uv pip compile against AIPCC index

## Test plan
- [ ] Konflux build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)