### PR TITLE
CVE-2026-8643: upgrade pip to fix path traversal in wheel installation

### DIFF
--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install CUDA
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install CUDA
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install CUDA
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install CUDA
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py311-rocm62-torch241/Dockerfile
+++ b/images/runtime/training/py311-rocm62-torch241/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install ROCm
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py311-rocm62-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-rocm62-torch241/Dockerfile.konflux
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install ROCm
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py311-rocm62-torch251/Dockerfile
+++ b/images/runtime/training/py311-rocm62-torch251/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install ROCm
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py311-rocm62-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-rocm62-torch251/Dockerfile.konflux
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install ROCm
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install CUDA
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install CUDA
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install CUDA
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
@@ -17,6 +17,7 @@ WORKDIR /app
 
 # upgrade requests package
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 # Install CUDA
 WORKDIR /opt/app-root/bin

--- a/images/runtime/training/py312-rocm64-torch280/Dockerfile
+++ b/images/runtime/training/py312-rocm64-torch280/Dockerfile
@@ -50,6 +50,9 @@ RUN dnf install -y cmake rocm-developer-tools rocm-ml-sdk rocm-openmp-sdk rocm-u
 
 # Install Python packages
 
+# Upgrade pip to fix CVE-2026-8643 (path traversal via malicious wheel entry point)
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 # Install micropipenv to deploy packages from Pipfile.lock
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 

--- a/images/runtime/training/py312-rocm64-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-rocm64-torch280/Dockerfile.konflux
@@ -38,6 +38,9 @@ RUN dnf install -y cmake rocm-developer-tools rocm-ml-sdk rocm-openmp-sdk rocm-u
 
 # Install Python packages
 
+# Upgrade pip to fix CVE-2026-8643 (path traversal via malicious wheel entry point)
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 # Install micropipenv to deploy packages from Pipfile.lock
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 

--- a/images/runtime/training/py312-rocm64-torch290/Dockerfile
+++ b/images/runtime/training/py312-rocm64-torch290/Dockerfile
@@ -78,6 +78,9 @@ RUN dnf install -y --setopt=install_weak_deps=False \
 
 # Install Python packages
 
+# Upgrade pip to fix CVE-2026-8643 (path traversal via malicious wheel entry point)
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 # Install micropipenv to deploy packages from Pipfile.lock
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 

--- a/images/runtime/training/py312-rocm64-torch290/Dockerfile.konflux
+++ b/images/runtime/training/py312-rocm64-torch290/Dockerfile.konflux
@@ -74,6 +74,9 @@ RUN dnf install -y --setopt=install_weak_deps=False \
 
 # Install Python packages
 
+# Upgrade pip to fix CVE-2026-8643 (path traversal via malicious wheel entry point)
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 # Install micropipenv to deploy packages from Pipfile.lock
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 


### PR DESCRIPTION
pip versions before 26.1.2 don't sanitize console_scripts/gui_scripts entry point names, allowing a malicious wheel to write files outside the intended scripts directory via path traversal sequences.

Adds `pip install --upgrade "pip>=26.1.2"` to all 8 training image variants (py311 and py312, CUDA and ROCm).

Ref: RHOAIENG-64042, RHOAIENG-64045, RHOAIENG-64047, RHOAIENG-64050
Ref: RHOAIENG-64051, RHOAIENG-64052, RHOAIENG-64054, RHOAIENG-64055
Ref: https://github.com/pypa/pip/pull/14000