### PR TITLE
CVE-2026-8643: upgrade pip to fix path traversal in wheel installation

### DIFF
--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
@@ -8,6 +8,8 @@ USER 0
 WORKDIR /app
 
 # upgrade requests package
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install CUDA

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
@@ -8,6 +8,8 @@ USER 0
 WORKDIR /app
 
 # upgrade requests package
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install CUDA

--- a/images/runtime/training/py311-rocm62-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-rocm62-torch241/Dockerfile.konflux
@@ -8,6 +8,8 @@ USER 0
 WORKDIR /app
 
 # upgrade requests package
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install ROCm

--- a/images/runtime/training/py311-rocm62-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-rocm62-torch251/Dockerfile.konflux
@@ -8,6 +8,8 @@ USER 0
 WORKDIR /app
 
 # upgrade requests package
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install ROCm

--- a/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch280/Dockerfile.konflux
@@ -8,6 +8,8 @@ USER 0
 WORKDIR /app
 
 # upgrade requests package
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install CUDA

--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile.konflux
@@ -16,6 +16,8 @@ USER 0
 WORKDIR /app
 
 # upgrade requests package
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install CUDA

--- a/images/runtime/training/py312-rocm64-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-rocm64-torch280/Dockerfile.konflux
@@ -39,6 +39,8 @@ RUN dnf install -y cmake rocm-developer-tools rocm-ml-sdk rocm-openmp-sdk rocm-u
 # Install Python packages
 
 # Install micropipenv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 
 # Install Python dependencies from Pipfile.lock file

--- a/images/runtime/training/py312-rocm64-torch290/Dockerfile.konflux
+++ b/images/runtime/training/py312-rocm64-torch290/Dockerfile.konflux
@@ -75,6 +75,8 @@ RUN dnf install -y --setopt=install_weak_deps=False \
 # Install Python packages
 
 # Install micropipenv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
+
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 
 # Install Python dependencies from Pipfile.lock file

--- a/images/universal/training/th06-cpu-torch210-py312/Dockerfile.konflux.cpu
+++ b/images/universal/training/th06-cpu-torch210-py312/Dockerfile.konflux.cpu
@@ -98,6 +98,8 @@ COPY LICENSE.md /licenses/cpu-license.md
 # Copy entrypoint
 COPY --chmod=0755 entrypoint-universal.sh /usr/local/bin/entrypoint-universal.sh
 
+RUN . /cachi2/cachi2.env && pip install --no-cache-dir --no-index --find-links "${PIP_FIND_LINKS}" --upgrade "pip>=26.1.2"
+
 # Fix permissions for OpenShift (final stage)
 RUN fix-permissions /opt/app-root -P \
  && chmod -R g+w /opt/app-root/lib/python${PYTHON_VERSION}/site-packages

--- a/images/universal/training/th06-cuda130-torch210-py312/Dockerfile.konflux.cuda
+++ b/images/universal/training/th06-cuda130-torch210-py312/Dockerfile.konflux.cuda
@@ -126,6 +126,8 @@ COPY LICENSE.md /licenses/cuda-license.md
 # Copy entrypoint
 COPY --chmod=0755 entrypoint-universal.sh /usr/local/bin/entrypoint-universal.sh
 
+RUN . /cachi2/cachi2.env && pip install --no-cache-dir --no-index --find-links "${PIP_FIND_LINKS}" --upgrade "pip>=26.1.2"
+
 # Fix permissions for OpenShift (final stage)
 RUN fix-permissions /opt/app-root -P \
  && chmod -R g+w /opt/app-root/lib/python${PYTHON_VERSION}/site-packages

--- a/images/universal/training/th06-rocm64-torch291-py312/Dockerfile.konflux.rocm
+++ b/images/universal/training/th06-rocm64-torch291-py312/Dockerfile.konflux.rocm
@@ -126,6 +126,8 @@ COPY LICENSE.md /licenses/rocm-license.md
 # Copy entrypoint
 COPY --chmod=0755 entrypoint-universal.sh /usr/local/bin/entrypoint-universal.sh
 
+RUN . /cachi2/cachi2.env && pip install --no-cache-dir --no-index --find-links "${PIP_FIND_LINKS}" --upgrade "pip>=26.1.2"
+
 # Fix permissions for OpenShift (final stage)
 RUN fix-permissions /opt/app-root -P \
  && chmod -R g+w /opt/app-root/lib/python${PYTHON_VERSION}/site-packages


### PR DESCRIPTION
Upgrade pip to >=26.1.2 in all training runtime and universal training (th06) Dockerfiles to fix CVE-2026-8643.

Resolves: RHOAIENG-64089, RHOAIENG-64090, RHOAIENG-64091, RHOAIENG-64093, RHOAIENG-64095, RHOAIENG-64098, RHOAIENG-64099, RHOAIENG-64101, RHOAIENG-64102, RHOAIENG-64104, RHOAIENG-64106, RHOAIENG-64107, RHOAIENG-64109