### PR TITLE
CVE-2026-8643: upgrade pip to fix path traversal in wheel installation

### DIFF
--- a/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda121-torch241/Dockerfile.konflux
@@ -7,7 +7,8 @@ COPY LICENSE.md /licenses/cuda-license.md
 USER 0
 WORKDIR /app
 
-# upgrade requests package
+# upgrade pip and requests packages
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install CUDA

--- a/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-cuda124-torch251/Dockerfile.konflux
@@ -7,7 +7,8 @@ COPY LICENSE.md /licenses/cuda-license.md
 USER 0
 WORKDIR /app
 
-# upgrade requests package
+# upgrade pip and requests packages
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install CUDA

--- a/images/runtime/training/py311-rocm62-torch241/Dockerfile.konflux
+++ b/images/runtime/training/py311-rocm62-torch241/Dockerfile.konflux
@@ -7,7 +7,8 @@ COPY LICENSE.md /licenses/rocm-license.md
 USER 0
 WORKDIR /app
 
-# upgrade requests package
+# upgrade pip and requests packages
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install ROCm

--- a/images/runtime/training/py311-rocm62-torch251/Dockerfile.konflux
+++ b/images/runtime/training/py311-rocm62-torch251/Dockerfile.konflux
@@ -7,7 +7,8 @@ COPY LICENSE.md /licenses/rocm-license.md
 USER 0
 WORKDIR /app
 
-# upgrade requests package
+# upgrade pip and requests packages
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 RUN pip install --no-cache-dir --upgrade requests==2.32.3
 
 # Install ROCm


### PR DESCRIPTION
Upgrade pip to >=26.1.2 in all training runtime Konflux Dockerfiles for RHOAI 2.25 to fix CVE-2026-8643.

Resolves: RHOAIENG-63994, RHOAIENG-63995, RHOAIENG-64003, RHOAIENG-64012