### PR TITLE
Bump peft 0.17.0 to 0.18.1 in torch280 training images

### DIFF
--- a/images/runtime/training/py312-cuda128-torch280/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch280/Pipfile
@@ -12,7 +12,7 @@ name = "pytorch-cu128"
 torch = {version = "==2.8.0", index = "pytorch-cu128"}
 accelerate = "==1.10.0"
 transformers = "~=5.5.0"
-peft = "==0.17.0"
+peft = "==0.18.1"
 tqdm = "==4.67.1"
 datasets = "==4.0.0"
 pydantic = ">=2.11.7"

--- a/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "994577df89d876af8edc8f46e9245603e26161e2e9e5188772935bd440c80b50"
+            "sha256": "9d9a20620029aa9560dedf76b72d51de2ec9550854399adac9f81359957828c1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1544,12 +1544,12 @@
         },
         "peft": {
             "hashes": [
-                "sha256:0190c28bdbdc24c3de549f2b42cd182cbb89d3e82aa3069c6db690c4ef6fccbb",
-                "sha256:cb647a931c8da434446d6a196c402b1c2d087b12e050e098215f906f12771f1e"
+                "sha256:0bf06847a3551e3019fc58c440cffc9a6b73e6e2962c95b52e224f77bbdb50f1",
+                "sha256:2dd0d6bfce936d1850e48aaddbd250941c5c02fc8ef3237cd8fd5aac35e0bae2"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.9.0'",
-            "version": "==0.17.0"
+            "markers": "python_full_version >= '3.10.0'",
+            "version": "==0.18.1"
         },
         "pluggy": {
             "hashes": [

--- a/images/runtime/training/py312-rocm64-torch280/Pipfile
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile
@@ -9,7 +9,7 @@ verify_ssl = true
 name = "pytorch-rocm64"
 
 [packages]
-peft = "==0.17.0"
+peft = "==0.18.1"
 datasets = "==4.0.0"
 liger-kernel = "==0.5.10"
 transformers = "~=5.5.0"

--- a/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fe3e4f94aca414e9416eb36f7ade23672fb19c8e454cbf7bf896427ce2f7a44b"
+            "sha256": "77794fff57cd34ec14d276efeb454037a0c7a9af4edf64375d9fcd738e287b51"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1596,12 +1596,12 @@
         },
         "peft": {
             "hashes": [
-                "sha256:0190c28bdbdc24c3de549f2b42cd182cbb89d3e82aa3069c6db690c4ef6fccbb",
-                "sha256:cb647a931c8da434446d6a196c402b1c2d087b12e050e098215f906f12771f1e"
+                "sha256:0bf06847a3551e3019fc58c440cffc9a6b73e6e2962c95b52e224f77bbdb50f1",
+                "sha256:2dd0d6bfce936d1850e48aaddbd250941c5c02fc8ef3237cd8fd5aac35e0bae2"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.9.0'",
-            "version": "==0.17.0"
+            "markers": "python_full_version >= '3.10.0'",
+            "version": "==0.18.1"
         },
         "platformdirs": {
             "hashes": [


### PR DESCRIPTION
peft 0.17.0 is incompatible with transformers 5.x — it tries to import HybridCache which was removed. This breaks all KFTO LLM training tests using the torch280 CUDA and ROCm images.


(cherry picked from commit b9fa0ea5e4397eb77cc92b2c92c34aea4165ff7d)