### PR TITLE
fix: disable build isolation in rocm280 konflux install step

### DIFF
--- a/images/runtime/training/py312-rocm64-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-rocm64-torch280/Dockerfile.konflux
@@ -46,7 +46,7 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]"
 # Install Python dependencies from Pipfile.lock file
 COPY Pipfile.lock ./
 
-RUN micropipenv install -- --no-cache-dir && \
+RUN PIP_NO_BUILD_ISOLATION=1 micropipenv install -- --no-cache-dir && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in OpenShift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \


### PR DESCRIPTION
Flash-attn requires torch during wheel build hooks, but pip build isolation in the konflux micropipenv install step can hide torch and fail image builds. Set PIP_NO_BUILD_ISOLATION=1 for this step so downstream konflux builds resolve flash-attn consistently.