### PR TITLE
fix: install rocm280 flash-attn outside lockfile step

### DIFF
--- a/images/runtime/training/py312-rocm64-torch280/Dockerfile
+++ b/images/runtime/training/py312-rocm64-torch280/Dockerfile
@@ -78,10 +78,6 @@ RUN export TMP_DIR=$(mktemp -d) \
 RUN chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P
 
-# Install flash-attn outside lockfile resolution; it needs torch visible at build time.
-RUN pip install --no-build-isolation --no-cache-dir --no-deps flash-attn==2.8.3 && \
-    fix-permissions /opt/app-root -P
-
 # Restore user workspace
 USER 1001
 

--- a/images/runtime/training/py312-rocm64-torch280/Dockerfile
+++ b/images/runtime/training/py312-rocm64-torch280/Dockerfile
@@ -78,6 +78,10 @@ RUN export TMP_DIR=$(mktemp -d) \
 RUN chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P
 
+# Install flash-attn outside lockfile resolution; it needs torch visible at build time.
+RUN pip install --no-build-isolation --no-cache-dir --no-deps flash-attn==2.8.3 && \
+    fix-permissions /opt/app-root -P
+
 # Restore user workspace
 USER 1001
 

--- a/images/runtime/training/py312-rocm64-torch280/Dockerfile.konflux
+++ b/images/runtime/training/py312-rocm64-torch280/Dockerfile.konflux
@@ -68,6 +68,10 @@ RUN export TMP_DIR=$(mktemp -d) \
 RUN chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P
 
+# Install flash-attn outside lockfile resolution; it needs torch visible at build time.
+RUN pip install --no-build-isolation --no-cache-dir --no-deps flash-attn==2.8.3 && \
+    fix-permissions /opt/app-root -P
+
 # Restore user workspace
 USER 1001
 

--- a/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
@@ -605,13 +605,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==3.29.1"
         },
-        "flash-attn": {
-            "hashes": [
-                "sha256:1e71dd64a9e0280e0447b8a0c2541bad4bf6ac65bdeaa2f90e51a9e57de0370d"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.8.3"
-        },
         "frozenlist": {
             "hashes": [
                 "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686",


### PR DESCRIPTION
Micropipenv lockfile installation still fails to build flash-attn even with PIP_NO_BUILD_ISOLATION set, because flash-attn build hooks cannot reliably see torch in that path. Remove flash-attn from the lockfile and install it explicitly with no-build-isolation after base dependencies are installed.