### PR TITLE
fix: remove flash-attn from rocm64-torch280 Pipfile.lock

### DIFF
--- a/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
@@ -468,13 +468,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==3.24.2"
         },
-        "flash-attn": {
-            "hashes": [
-                "sha256:1e71dd64a9e0280e0447b8a0c2541bad4bf6ac65bdeaa2f90e51a9e57de0370d"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.8.3"
-        },
         "frozenlist": {
             "hashes": [
                 "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686",
@@ -2378,9 +2371,9 @@
                 "sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d",
                 "sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==0.46.3",
-            "index": "pypi"
+            "version": "==0.46.3"
         },
         "wrapt": {
             "hashes": [


### PR DESCRIPTION
flash-attn requires torch at build time but micropipenv installs packages sequentially from the lockfile. Remove flash-attn from Pipfile.lock since it's already installed separately in the Dockerfile with --no-build-isolation after torch is available.

Cherry-pick of 2626e9b from main.