### PR TITLE
fix: remove flash-attn from cuda128-torch280 Pipfile.lock

### DIFF
--- a/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
@@ -447,13 +447,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==3.29.1"
         },
-        "flash-attn": {
-            "hashes": [
-                "sha256:1e71dd64a9e0280e0447b8a0c2541bad4bf6ac65bdeaa2f90e51a9e57de0370d"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.8.3"
-        },
         "frozenlist": {
             "hashes": [
                 "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686",


### PR DESCRIPTION
flash-attn requires torch at build time but micropipenv installs packages sequentially from the lockfile. Remove flash-attn from Pipfile.lock since it's already installed separately in the Dockerfile with --no-build-isolation after torch is available.