### PR TITLE
CVE-2026-54283: bump starlette 1.2.0 → 1.3.1

### DIFF
--- a/images/runtime/training/py312-cuda128-torch290/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile
@@ -50,8 +50,7 @@ pyasn1 = "==0.6.3"
 mlflow = "==3.10.1"
 cryptography = ">=46.0.7"
 urllib3 = ">=2.7.0"
-starlette = ">=1.0.1"
-
+starlette = "~=1.3.1"
 pillow = ">=12.3.0"
 [dev-packages]
 

--- a/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c86943bfe376758600e62eb19367a19866baadc306dd62761ddb398bd42315dd"
+            "sha256": "d6eb90981c3c1018e97fdc60ad3272d543ce01d79fbdffb67eccb65372ef1a6f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -215,11 +215,11 @@
         },
         "anyio": {
             "hashes": [
-                "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708",
-                "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"
+                "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494",
+                "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.13.0"
+            "version": "==4.14.2"
         },
         "async-timeout": {
             "hashes": [
@@ -3456,12 +3456,12 @@
         },
         "starlette": {
             "hashes": [
-                "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f",
-                "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd"
+                "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0",
+                "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==1.0.1"
+            "version": "==1.3.1"
         },
         "sympy": {
             "hashes": [
@@ -3672,11 +3672,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
-                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8",
+                "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==4.15.0"
+            "version": "==4.16.0"
         },
         "typing-inspection": {
             "hashes": [


### PR DESCRIPTION
## Summary

Cherry-pick of opendatahub-io/distributed-workloads#956 to rhoai-3.3.

- Bump `starlette` to 1.3.1 to fix **CVE-2026-54283** (CVSS 7.5) — `request.form()` limits silently ignored for `application/x-www-form-urlencoded`, enabling DoS
- Runtime images only (th06 universal images don't exist on 3.3): cuda128 Pipfile + re-lock

## Test plan

- [ ] Verify Konflux builds succeed
- [ ] Verify `pip show starlette` shows 1.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)