### PR TITLE
[RHOAI 3.4] CVE-2026-42215/42284/44244: bump GitPython 3.1.46 → 3.1.50

### DIFF
--- a/images/runtime/training/py312-cuda128-torch290/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile
@@ -53,6 +53,7 @@ simpleeval = "==1.0.7"
 urllib3 = ">=2.7.0"
 starlette = "~=1.3.1"
 pillow = ">=12.3.0"
+gitpython = "~=3.1.50"
 
 [dev-packages]
 

--- a/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a9e201761400ea6613914aa4032e51c9df7b065aecab3677488f07e0ad51f5f7"
+            "sha256": "9d810b0ae6c2502f5aad49fa55bee018b925b194ad059e947121613e96872a08"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1013,11 +1013,12 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f",
-                "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058"
+                "sha256:79a36ee1f83523214a3f72d56cf1c4e490d577dc61af77e43dfe5862bd9da01a",
+                "sha256:de0a8ad86274c6e75ae8b37dd055ba68f19818c813108642263227b20775b48e"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.46"
+            "version": "==3.1.52"
         },
         "google-auth": {
             "hashes": [

--- a/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
@@ -85,5 +85,6 @@ index-strategy = "unsafe-best-match"
 index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/"
 constraint-dependencies = [
     "aiohttp~=3.14.0",
+    "gitpython~=3.1.50",
     "starlette~=1.3.1",
 ]

--- a/images/universal/training/th06-cpu-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cpu-torch210-py312/requirements.txt
@@ -139,7 +139,7 @@ fsspec==2025.9.0
     #   training-hub
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.46
+gitpython==3.1.50
     # via mlflow-skinny
 google-auth==2.49.2
     # via databricks-sdk

--- a/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
@@ -103,5 +103,6 @@ index-strategy = "unsafe-best-match"
 index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda13.0-ubi9/simple/"
 constraint-dependencies = [
     "aiohttp~=3.14.0",
+    "gitpython~=3.1.50",
     "starlette~=1.3.1",
 ]

--- a/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
@@ -167,7 +167,7 @@ fsspec==2025.9.0
     #   training-hub
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.46
+gitpython==3.1.50
     # via mlflow-skinny
 google-auth==2.49.2
     # via databricks-sdk

--- a/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
+++ b/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
@@ -90,5 +90,6 @@ index-strategy = "unsafe-best-match"
 index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9/simple/"
 constraint-dependencies = [
     "aiohttp~=3.14.0",
+    "gitpython~=3.1.50",
     "starlette~=1.3.1",
 ]

--- a/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
+++ b/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
@@ -160,7 +160,7 @@ fsspec==2025.9.0
     #   training-hub
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.46
+gitpython==3.1.50
     # via mlflow-skinny
 google-auth==2.49.1
     # via databricks-sdk


### PR DESCRIPTION
## Summary

Cherry-pick of opendatahub-io/distributed-workloads#957 to rhoai-3.4.

- Bump `GitPython` 3.1.46 → 3.1.50 to fix 3 CVEs (CVSS 7.3–8.8)
- Universal images (th06): all 3 variants updated
- Runtime images: cuda128 — added as direct Pipfile dep + re-locked

## CVEs Fixed

| CVE | CVSS | Description |
|---|---|---|
| CVE-2026-42215 | 8.8 | OS command injection via kwargs bypass |
| CVE-2026-42284 | 7.5 | Argument injection via multi_options |
| CVE-2026-44244 | 7.3 | Newline injection in config_writer → RCE |

## Test plan

- [ ] Verify Konflux builds succeed
- [ ] Verify `pip show gitpython` shows >= 3.1.50

🤖 Generated with [Claude Code](https://claude.com/claude-code)