### PR TITLE
[RHOAI 3.3] CVE-2026-42215/42284/44244: bump GitPython 3.1.46 → 3.1.50

### DIFF
--- a/images/runtime/training/py312-cuda128-torch290/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile
@@ -52,6 +52,8 @@ cryptography = ">=46.0.7"
 urllib3 = ">=2.7.0"
 starlette = "~=1.3.1"
 pillow = ">=12.3.0"
+gitpython = "~=3.1.50"
+
 [dev-packages]
 
 [requires]

--- a/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d6eb90981c3c1018e97fdc60ad3272d543ce01d79fbdffb67eccb65372ef1a6f"
+            "sha256": "956727c3d1546781354fc08b6c1313c0cc1c4a4e5b05685c11d7488f82f94b77"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -989,11 +989,12 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f",
-                "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058"
+                "sha256:79a36ee1f83523214a3f72d56cf1c4e490d577dc61af77e43dfe5862bd9da01a",
+                "sha256:de0a8ad86274c6e75ae8b37dd055ba68f19818c813108642263227b20775b48e"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.46"
+            "version": "==3.1.52"
         },
         "google-auth": {
             "hashes": [


### PR DESCRIPTION
## Summary

Cherry-pick of opendatahub-io/distributed-workloads#957 to rhoai-3.3.

- Bump `GitPython` 3.1.46 → 3.1.50 to fix 3 CVEs (CVSS 7.3–8.8)
- Runtime images only (th06 doesn't exist on 3.3): cuda128 — added as direct Pipfile dep + re-locked

## CVEs Fixed

| CVE | CVSS | Description |
|---|---|---|
| CVE-2026-42215 | 8.8 | OS command injection via kwargs bypass |
| CVE-2026-42284 | 7.5 | Argument injection via multi_options |
| CVE-2026-44244 | 7.3 | Newline injection in config_writer → RCE |

## Test plan

- [ ] Verify Konflux builds succeed
- [ ] Verify `pip show gitpython` shows >= 3.1.50

🤖 Generated with [Claude Code](https://claude.com/claude-code)