### PR TITLE
[RHOAI 3.4] CVE-2026-54058 + 7 others: bump Pillow 12.2.0 → 12.3.0 in th06 universal training images

### DIFF
--- a/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
@@ -86,5 +86,6 @@ index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/
 constraint-dependencies = [
     "aiohttp~=3.14.0",
     "gitpython~=3.1.50",
+    "pillow~=12.3.0",
     "starlette~=1.3.1",
 ]

--- a/images/universal/training/th06-cpu-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cpu-torch210-py312/requirements.txt
@@ -351,7 +351,7 @@ peft==0.18.1
     #   th06-cpu-universal-image (pyproject.toml)
     #   instructlab-training
     #   training-hub
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   matplotlib
     #   tensorboard

--- a/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
@@ -104,5 +104,6 @@ index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda13.0-
 constraint-dependencies = [
     "aiohttp~=3.14.0",
     "gitpython~=3.1.50",
+    "pillow~=12.3.0",
     "starlette~=1.3.1",
 ]

--- a/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
@@ -426,7 +426,7 @@ peft==0.18.1
     #   training-hub
     #   unsloth
     #   unsloth-zoo
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   diffusers
     #   matplotlib

--- a/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
+++ b/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
@@ -91,5 +91,6 @@ index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-u
 constraint-dependencies = [
     "aiohttp~=3.14.0",
     "gitpython~=3.1.50",
+    "pillow~=12.3.0",
     "starlette~=1.3.1",
 ]

--- a/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
+++ b/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
@@ -410,7 +410,7 @@ peft==0.18.1
     #   training-hub
     #   unsloth
     #   unsloth-zoo
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   diffusers
     #   matplotlib


### PR DESCRIPTION
## Summary
- Bump `pillow` 12.2.0 → 12.3.0 in all three th06 universal training image variants (cpu, cuda130, rocm64)
- Add `pillow~=12.3.0` to `constraint-dependencies` in each `pyproject.toml` to prevent regression
- Pillow 12.3.0 verified available on all three AIPCC indexes
- Midstream PR: https://github.com/opendatahub-io/distributed-workloads/pull/962

## CVEs Addressed (8)
- **CVE-2026-54058** (CVSS 9.1) — Memory disclosure or DoS via crafted McIdas AREA image
- **CVE-2026-59199** (CVSS 7.5) — DoS via out-of-bounds write in image processing
- **CVE-2026-59200** (CVSS 7.5) — DoS via crafted PDF stream
- **CVE-2026-59204** (CVSS 7.5) — DoS via crafted JPEG2000 image
- **CVE-2026-59205** (CVSS 7.5) — Heap corruption in ImageCms.ImageCmsTransform.apply
- **CVE-2026-54060** (CVSS 7.5) — DoS via excessive memory allocation
- **CVE-2026-55379** (CVSS 7.5) — DoS via crafted BDF font file
- **CVE-2026-55380** (CVSS 7.5) — DoS via crafted GD 2.x image file

## Test plan
- [ ] Verify Pillow 12.3.0 installs correctly in each image build
- [ ] Confirm no dependency conflicts with existing packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)