### PR TITLE
Add Dockerfile.konflux for 3.5 universal ROCm training image

### DIFF
--- a/images/universal/training/th-torch-rocm-py312/Dockerfile.konflux
+++ b/images/universal/training/th-torch-rocm-py312/Dockerfile.konflux
@@ -1,0 +1,141 @@
+# ROCm Universal Image Dockerfile
+#
+# FIPS-friendly Features:
+# - Build tools are isolated in intermediate stage
+# - Final image contains only runtime dependencies
+# - Uses pip install (additive) to preserve base image packages
+#
+# Build Modes:
+# - Midstream (default): DOWNSTREAM=false - installs system packages and sets env vars
+# - Downstream: DOWNSTREAM=true - skips midstream-only sections (base image has them)
+
+################################################################################
+# Build Arguments
+################################################################################
+ARG BASE_IMAGE=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:41814c7ec8076c53a57ad4eba7ed4ab3da4b6192dafcf63a8e91ff63e8859bea
+ARG PYTHON_VERSION=3.12
+ARG DOWNSTREAM=false
+
+################################################################################
+# Build Stage - Install Python Dependencies
+################################################################################
+FROM ${BASE_IMAGE} AS builder
+
+USER 0
+WORKDIR /tmp/deps
+
+# Copy requirements file (single consolidated lockfile with GA index)
+COPY --chown=1001:0 pyproject.toml requirements.txt ./
+
+# Switch to user 1001 for pip installations
+USER 1001
+WORKDIR /opt/app-root/src
+
+# Install dependencies from cachi2 prefetched packages
+# cachi2.env sets PIP_FIND_LINKS and PIP_NO_INDEX, but uv ignores PIP_* vars,
+# so we pass them explicitly as CLI flags
+RUN . /cachi2/cachi2.env && uv pip install --no-cache-dir \
+    --no-index --find-links "${PIP_FIND_LINKS}" \
+    -r /tmp/deps/requirements.txt
+
+# Fix permissions for OpenShift
+ARG PYTHON_VERSION
+USER 0
+RUN chmod -R g+w /opt/app-root/lib/python${PYTHON_VERSION}/site-packages \
+ && fix-permissions /opt/app-root -P
+
+# Clean up
+RUN rm -rf /tmp/deps
+
+################################################################################
+# Final Stage - FIPS-friendly Runtime
+################################################################################
+FROM ${BASE_IMAGE} AS final
+
+LABEL name="th-torch-rocm-py312" \
+      summary="ROCm 7.14 Python 3.12 Training Hub 09 PyTorch 2.11.0 image on UBI9" \
+      description="Universal ROCm image combining Jupyter workbench and runtime ML stack on UBI9" \
+      io.k8s.display-name="ROCm Python 3.12 Universal Training Image" \
+      io.k8s.description="Universal ROCm training image: Jupyter workbench by default; runtime when command provided."
+
+USER 0
+WORKDIR /opt/app-root/src
+
+################################################################################
+# MIDSTREAM ONLY: Environment variables and system packages
+# Controlled by ARG DOWNSTREAM (default: false)
+# - DOWNSTREAM=false (midstream): Installs ROCm dev tools, RDMA packages, sets env vars
+# - DOWNSTREAM=true: Skips this section (AIPCC base image has everything pre-configured)
+################################################################################
+ARG DOWNSTREAM
+
+# ROCm 7.14 environment variables
+# ROCM_HOME=/opt/rocm/core per ROCm 7.14 layout (backward compat symlinks at /opt/rocm/)
+ENV ROCM_HOME=/opt/rocm/core \
+    HIP_PATH=/opt/rocm/core \
+    PATH=/opt/rocm/core/bin:/opt/rocm/core/hip/bin:${PATH} \
+    LD_LIBRARY_PATH=/usr/local/lib64/glibc-compat:/opt/rocm/core/lib:/opt/rocm/core/lib64:${LD_LIBRARY_PATH}
+
+# PyArrow TLS workaround (RHELAI-2417)
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
+# System packages (MIDSTREAM ONLY - skipped when DOWNSTREAM=true)
+# ROCm 7.14 uses THEROCK repositories (amdrocm-* packages)
+# COPY rocm.repo mellanox.repo /etc/yum.repos.d/
+
+RUN if [ "${DOWNSTREAM}" != "true" ]; then \
+    echo "MIDSTREAM BUILD: Installing system packages..." && \
+    dnf install -y --setopt=install_weak_deps=False \
+        perl \
+        mesa-libGL \
+        skopeo \
+        libibverbs-utils \
+        infiniband-diags \
+        libibumad \
+        librdmacm \
+        librdmacm-utils \
+        rdma-core \
+        amdrocm-llvm \
+        amdrocm-runtime \
+        amdrocm-runtime-devel \
+        amdrocm-core-sdk \
+        amdrocm-core-devel \
+        protobuf && \
+    dnf clean all && rm -rf /var/cache/dnf/* && \
+    # Backward compat symlinks for /opt/rocm
+    ln -sfn /opt/rocm/core/include /opt/rocm/include && \
+    ln -sfn /opt/rocm/core/lib /opt/rocm/lib && \
+    ln -sfn /opt/rocm/core/bin /opt/rocm/bin && \
+    ln -sfn /opt/rocm/core/share /opt/rocm/share; \
+else \
+    echo "DOWNSTREAM BUILD: Skipping system packages (provided by base image)"; \
+fi
+################################################################################
+# END MIDSTREAM ONLY
+################################################################################
+
+# Copy Python site-packages and CLI entry points from builder stage
+ARG PYTHON_VERSION
+COPY --from=builder /opt/app-root/lib/python${PYTHON_VERSION}/site-packages /opt/app-root/lib/python${PYTHON_VERSION}/site-packages
+COPY --from=builder /opt/app-root/bin /opt/app-root/bin
+
+# Remove uv from final image (not needed at runtime)
+RUN rm -f /opt/app-root/bin/uv
+
+# Copy license file
+COPY LICENSE.md /licenses/rocm-license.md
+
+# Copy entrypoint
+COPY --chmod=0755 entrypoint-universal.sh /usr/local/bin/entrypoint-universal.sh
+
+RUN . /cachi2/cachi2.env && pip install --no-cache-dir --no-index --find-links "${PIP_FIND_LINKS}" --upgrade "pip>=26.1.2"
+
+# Fix permissions for OpenShift (final stage)
+RUN fix-permissions /opt/app-root -P \
+ && chmod -R g+w /opt/app-root/lib/python${PYTHON_VERSION}/site-packages
+
+USER 1001
+WORKDIR /opt/app-root/src
+
+ENTRYPOINT ["/usr/local/bin/entrypoint-universal.sh"]
+CMD ["start-notebook.sh"]


### PR DESCRIPTION
## Summary
- Add `Dockerfile.konflux` for `th-torch-rocm-py312` universal training image (ROCm 7.14, PyTorch 2.11.0)
- Adapted from midstream `Dockerfile` with cachi2 prefetch, `registry.redhat.io` digest-pinned base image, and pip upgrade via cachi2

## Changes
Key Konflux adaptations from the midstream Dockerfile:
- **Base image**: `registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9` with SHA256 digest
- **Builder stage**: cachi2 prefetch (`--no-index --find-links`) instead of AIPCC index URL
- **ROCm repo files**: Commented out (not needed in Konflux builds)
- **Pip upgrade**: Added via cachi2 in final stage (`pip>=26.1.2`)

Carried over from midstream:
- ROCm 7.14 env vars (`ROCM_HOME=/opt/rocm/core` per new layout)
- PyArrow TLS workaround (`LD_PRELOAD=/usr/lib64/libjemalloc.so.2`)
- THEROCK packages (`amdrocm-llvm`, `amdrocm-runtime`, etc.)
- Backward compat symlinks for `/opt/rocm`
- `protobuf` system package

## Test plan
- [ ] Verify Konflux pipeline builds successfully for ROCm variant
- [ ] Confirm cachi2 dependency prefetch resolves all packages
- [ ] Validate base image digest is picked up by Konflux nudging


Made with [Cursor](https://cursor.com)