### PR TITLE
Fix compilation error from cherry-pick of custom CTR upgrade test

### DIFF
--- a/tests/trainer/trainer_kueue_upgrade_training_test.go
+++ b/tests/trainer/trainer_kueue_upgrade_training_test.go
@@ -322,7 +322,7 @@ func TestSetupCustomRuntimeUpgradeTrainJob(t *testing.T) {
 	SetupKueue(test, initialKueueState, TrainJobFramework)
 
 	// Get image from the default CUDA runtime to use in our custom CTR
-	image, err := trainerutils.GetImageFromClusterTrainingRuntime(test, trainerutils.DefaultClusterTrainingRuntimeCUDA)
+	image, err := trainerutils.GetImageFromClusterTrainingRuntime(test, trainerutils.DefaultClusterTrainingRuntime)
 	test.Expect(err).NotTo(HaveOccurred())
 
 	// Create custom ClusterTrainingRuntime

--- a/tests/trainer/utils/utils_runtimes.go
+++ b/tests/trainer/utils/utils_runtimes.go
@@ -16,6 +16,15 @@ limitations under the License.
 
 package trainer
 
+import (
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/distributed-workloads/tests/common/support"
+)
+
 // ClusterTrainingRuntime represents a ClusterTrainingRuntime with its expected RHOAI image
 type ClusterTrainingRuntime struct {
 	Name       string
@@ -46,6 +55,25 @@ func IsDefaultRuntime(name string) bool {
 		}
 	}
 	return false
+}
+
+func GetImageFromClusterTrainingRuntime(test support.Test, runtimeName string) (string, error) {
+	runtime, err := test.Client().Trainer().TrainerV1alpha1().ClusterTrainingRuntimes().Get(
+		test.Ctx(),
+		runtimeName,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to get ClusterTrainingRuntime %q: %w", runtimeName, err)
+	}
+	for _, replicatedJob := range runtime.Spec.Template.Spec.ReplicatedJobs {
+		for _, container := range replicatedJob.Template.Spec.Template.Spec.Containers {
+			if container.Image != "" {
+				return container.Image, nil
+			}
+		}
+	}
+	return "", errors.New("no container image found in ClusterTrainingRuntime " + runtimeName)
 }
 
 // ExpectedRuntimes is the list of expected ClusterTrainingRuntimes on the cluster


### PR DESCRIPTION
The cherry-pick of 99b51db introduced references to DefaultClusterTrainingRuntimeCUDA and GetImageFromClusterTrainingRuntime which don't exist on this branch. Use the existing DefaultClusterTrainingRuntime constant and add the missing GetImageFromClusterTrainingRuntime helper function.