### PR TITLE
fix: bump aiohttp to 3.14.3 in py312-rocm64-torch29-openmpi41

### DIFF
--- a/images/runtime/training/py312-rocm64-torch29-openmpi41/pyproject.toml
+++ b/images/runtime/training/py312-rocm64-torch29-openmpi41/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "simpleeval>=0.9.13",
     "safetensors==0.7.0",
     "py-cpuinfo>=9.0.0",
-    "aiohttp>=3.13.3",
+    "aiohttp==3.14.3",
 
     # Deep Learning Utilities
     "numba>=0.61.2",

--- a/images/runtime/training/py312-rocm64-torch29-openmpi41/requirements.txt
+++ b/images/runtime/training/py312-rocm64-torch29-openmpi41/requirements.txt
@@ -70,7 +70,6 @@ certifi==2026.2.25
     # via
     #   httpcore
     #   httpx
-    #   kubernetes
     #   requests
 cffi==2.0.0
     # via cryptography
@@ -167,9 +166,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via mlflow-skinny
 google-auth==2.48.0
-    # via
-    #   databricks-sdk
-    #   kubernetes
+    # via databricks-sdk
 graphene==3.4.3
     # via mlflow
 graphql-core==3.2.7
@@ -252,8 +249,6 @@ kernels==0.12.1
     # via py312-rocm64-torch29-openmpi41 (pyproject.toml)
 kiwisolver==1.4.9
     # via matplotlib
-kubernetes==30.1.0
-    # via mlflow
 liger-kernel==0.7.0
     # via py312-rocm64-torch29-openmpi41 (pyproject.toml)
 llvmlite==0.46.0
@@ -384,10 +379,6 @@ nvidia-nvshmem-cu12==3.3.20
     # via torch
 nvidia-nvtx-cu12==12.8.90
     # via torch
-oauthlib==3.3.1
-    # via
-    #   kubernetes
-    #   requests-oauthlib
 opentelemetry-api==1.40.0
     # via
     #   mlflow-skinny
@@ -516,7 +507,6 @@ python-dateutil==2.9.0.post0
     #   aiobotocore
     #   botocore
     #   graphene
-    #   kubernetes
     #   matplotlib
     #   pandas
 python-dotenv==1.2.2
@@ -530,7 +520,6 @@ pyyaml==6.0.3
     #   huggingface-hub
     #   instructlab-training
     #   kernels
-    #   kubernetes
     #   mlflow-skinny
     #   peft
     #   transformers
@@ -547,13 +536,9 @@ requests==2.32.5
     #   diffusers
     #   docker
     #   huggingface-hub
-    #   kubernetes
     #   mlflow-skinny
-    #   requests-oauthlib
     #   training-hub
     #   transformers
-requests-oauthlib==2.0.0
-    # via kubernetes
 rhai-innovation-mini-trainer==0.6.1
     # via
     #   py312-rocm64-torch29-openmpi41 (pyproject.toml)
@@ -601,9 +586,7 @@ shellingham==1.5.4
 simpleeval==1.0.7
     # via py312-rocm64-torch29-openmpi41 (pyproject.toml)
 six==1.17.0
-    # via
-    #   kubernetes
-    #   python-dateutil
+    # via python-dateutil
 skops==0.13.0
     # via mlflow
 smmap==5.0.2
@@ -699,6 +682,7 @@ typer==0.24.1
     #   rhai-innovation-mini-trainer
 typing-extensions==4.15.0
     # via
+    #   aiohttp
     #   aiosignal
     #   alembic
     #   anyio
@@ -737,15 +721,12 @@ urllib3==2.6.3
     # via
     #   botocore
     #   docker
-    #   kubernetes
     #   requests
     #   training-hub
 uvicorn==0.41.0
     # via mlflow-skinny
 wcwidth==0.6.0
     # via prettytable
-websocket-client==1.9.0
-    # via kubernetes
 werkzeug==3.1.6
     # via
     #   flask

--- a/images/runtime/training/py312-rocm64-torch29-openmpi41/requirements.txt
+++ b/images/runtime/training/py312-rocm64-torch29-openmpi41/requirements.txt
@@ -23,7 +23,7 @@ aiofiles==25.1.0
     #   training-hub
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.3
     # via
     #   py312-rocm64-torch29-openmpi41 (pyproject.toml)
     #   aiobotocore


### PR DESCRIPTION
## Summary
- Bumps `aiohttp` from `>=3.13.3` (locked 3.13.3) to `==3.14.3` in `images/runtime/training/py312-rocm64-torch29-openmpi41` (`pyproject.toml` + `requirements.txt`).
- Addresses CVE-2026-69244 (OOB heap read in the C response parser; product status: affected before 3.14.3).
- 3.14.3 is on the image AIPCC index (`rhoai/3.4/rocm6.4-ubi9`). Transitive deps already satisfy 3.14.3.

## Test plan
- [ ] `aiohttp==3.14.3` resolves from `--index-url=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9/simple/`
- [ ] `pip install -r requirements.txt` / image build succeeds